### PR TITLE
슬랙 알림 Util 개발 & Member Entity 수정

### DIFF
--- a/seekgu/build.gradle
+++ b/seekgu/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+
+    // slack
+    implementation "com.slack.api:slack-api-client:1.25.1"
 }
 
 tasks.named('test') {

--- a/seekgu/src/main/java/com/seekgu/member/domain/Member.java
+++ b/seekgu/src/main/java/com/seekgu/member/domain/Member.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class Member {
     private Long memberIdx;
     private String memberNickName;
+    private String memberName;
     private String memberId;
     private String memberPw;
     private Gender memberGender;

--- a/seekgu/src/main/java/com/seekgu/member/domain/Member.java
+++ b/seekgu/src/main/java/com/seekgu/member/domain/Member.java
@@ -15,5 +15,6 @@ public class Member {
     private String memberName;
     private String memberId;
     private String memberPw;
+    private String memberSlackId;
     private Gender memberGender;
 }

--- a/seekgu/src/main/java/com/seekgu/utils/slack/SlackService.java
+++ b/seekgu/src/main/java/com/seekgu/utils/slack/SlackService.java
@@ -53,6 +53,17 @@ public class SlackService {
 			sendMessage(slackId, makeRecruitmentCompletionNotiMessage()));
 	}
 
+	public static void addMemberToChannel(String slackId) {
+		try {
+			client.conversationsInvite(r -> r
+				.token(token)
+				.channel(channelId)
+				.users(List.of(slackId)));
+		} catch (IOException | SlackApiException e) {
+			throw new RuntimeException("SLACK_API_FAILURE");
+		}
+	}
+
 	private static List<User> fetchUsers() {
 		try {
 			var result = client.usersList(r -> r

--- a/seekgu/src/main/java/com/seekgu/utils/slack/SlackService.java
+++ b/seekgu/src/main/java/com/seekgu/utils/slack/SlackService.java
@@ -1,0 +1,56 @@
+package com.seekgu.utils.slack;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.slack.api.Slack;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.User;
+
+@Service
+public class SlackService {
+
+	static String token;
+	static String channelId;
+
+	@Value(value = "${slack.token}")
+	private void setToken(String value) {
+		token = value;
+	}
+
+	@Value(value = "${slack.channel-id}")
+	private void setChannelId(String value) {
+		channelId = value;
+	}
+
+	public static String getSlackIdByMemberName(String memberName) {
+		List<User> users = fetchUsers();
+		Optional<String> userSlackId = Optional.empty();
+		for(User user : users) {
+			if(user.getProfile().getRealName().equals(memberName)) {
+				userSlackId = Optional.of(user.getId());
+			}
+		}
+
+		return userSlackId.orElseThrow(() -> {
+			throw new RuntimeException("SLACK_ID_NOT_FOUND");
+		});
+
+	}
+
+	private static List<User> fetchUsers() {
+		var client = Slack.getInstance().methods();
+		try {
+			var result = client.usersList(r -> r
+				.token(token)
+			);
+			return result.getMembers();
+		} catch (IOException | SlackApiException e) {
+			throw new RuntimeException("SLACK_API_FAILURE");
+		}
+	}
+}

--- a/seekgu/src/main/java/com/seekgu/utils/slack/SlackUtil.java
+++ b/seekgu/src/main/java/com/seekgu/utils/slack/SlackUtil.java
@@ -5,15 +5,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.model.User;
 
-@Service
-public class SlackService {
+@Component
+public class SlackUtil {
 
 	static String token;
 	static String channelId;


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #5 

## 🔑 Key Changes

1. member entity에 memberName, memberSlackId 컬럼 추가하였습니다.
2. 슬랙 알림 util을 구현하였습니다. 
  - 이름으로 memberSlackId 찾기
  - 슬랙 채널에 메세지 보내기, 개인 DM 보내기
  - 채널에 멤버 추가하기

## 📢 To Reviewers
- 